### PR TITLE
Update to caching behavior requests for calls to API /assets endpoint

### DIFF
--- a/components/utils/webCOOSHelpers.js
+++ b/components/utils/webCOOSHelpers.js
@@ -250,6 +250,7 @@ async function getAPIAssets({
     apiVersion = 'v1',
     source = 'webcoos',
     token = process.env.NEXT_PUBLIC_WEBCOOS_API_TOKEN,
+    allow_cached = true,
     slug
 } = {}) {
     if (!token) {
@@ -261,7 +262,7 @@ async function getAPIAssets({
         apiVersion,
         'assets',
         ...(!!slug ? [slug] : []),
-        `?source=${source}&_nocache=true`
+        `?source=${source}${(!!allow_cached ? '' : '&_nocache=true')}`
     ],
         url = parts.join('/');
 

--- a/pages/cameras/[slug].js
+++ b/pages/cameras/[slug].js
@@ -174,7 +174,7 @@ export default function CameraPage({ metadata, slug, rawMetadata, parsedMetadata
 export async function getStaticPaths() {
     // pull live metadata from API
     try {
-        const cameraMetadataResult = await getAPIAssets(),
+        const cameraMetadataResult = await getAPIAssets({ allow_cached: false }),
             activeSlugs = cameraMetadataResult.results
             .map((r) => {
                 const parsed = parseWebCOOSAsset(r);
@@ -209,7 +209,7 @@ export async function getStaticPaths() {
 
 export async function getStaticProps({ params }) {
     try {
-        const cameraMetadataResult = await getAPIAssets({ slug: params.slug }),
+        const cameraMetadataResult = await getAPIAssets({ slug: params.slug, allow_cached: false }),
             parsedMetadata = parseWebCOOSAsset(cameraMetadataResult),
             sanitized = Object.fromEntries(
                 Object.entries(parsedMetadata).map((p) => {

--- a/pages/cameras/index.js
+++ b/pages/cameras/index.js
@@ -416,7 +416,7 @@ export async function getStaticProps() {
 
     // pull live metadata from API
     try {
-        const cameraMetadataResult = await getAPIAssets(),
+        const cameraMetadataResult = await getAPIAssets( { allow_cached: false } ),
             parsedMetadata = cameraMetadataResult.results
                 .map((r) => {
                     const parsed = parseWebCOOSAsset(r);

--- a/pages/index.js
+++ b/pages/index.js
@@ -80,7 +80,7 @@ export default function Home({ content, metadata, activeSlugs }) {
 
 export async function getStaticProps() {
     try {
-        const cameraMetadataResult = await getAPIAssets(),
+        const cameraMetadataResult = await getAPIAssets({allow_cached: false}),
             activeSlugs = cameraMetadataResult.results
                 .map((r) => {
                     const parsed = parseWebCOOSAsset(r);


### PR DESCRIPTION
Update _nocache=true handling for statics vs. dynamic page requests (don't allow for caching when generating static paths/props, but do allow for caching when requesting assets from the /cameras page).