### PR TITLE
Fix product reference for Georgetown media

### DIFF
--- a/md-content/products.md
+++ b/md-content/products.md
@@ -9,8 +9,8 @@ show_product_grid: true
 WebCOOS cameras are collecting video and images which can be used for general coastal observing purposes. For example, our [Point Reyes National Seashore camera](https://webcoos.org/cameras/tmmc_prls/) is being used to allow users to view rehabilitated patient releases from The Marine Mammal Center.  The [camera at the South Carolina Maritime Museum in Georgetown, SC](https://webcoos.org/cameras/georgetownscmm/) is being used to monitor river use on the Sampit River, people traffic at events, and to remotely evaluate flooding impacts during storms.
 
 <video width="600" className='object-contain' autoplay controls >
-    <source src='https://s3.us-west-2.amazonaws.com/webcoos-stage/media/sources/webcoos/groups/scmm/assets/georgetownscmm/feeds/raw-video-data/products/time-lapse/elements/2022/10/15/georgetownscmm-2022-10-15-000000Z.mp4#t=22' type='video/mp4' />
+    <source src='https://webcoos.s3.us-west-2.amazonaws.com/media/sources/webcoos/groups/scmm/assets/georgetownscmm/feeds/raw-video-data/products/time-lapse/elements/2023/10/21/georgetownscmm-2023-10-21-040000Z.mp4' type='video/mp4' />
 </video>
-<sub>Example time lapse video from the South Carolina Maritime Museum Annual Boat Show on Saturday, October 15, 2022.</sub>
+<sub>Example time lapse video from the South Carolina Maritime Museum Annual Boat Show on Saturday, October 21, 2023.</sub>
 
 For many cameras, the images and videos are also being further analyzed for uses such as identifying rip currents, monitoring beach usage, and studying beach erosion. The products of the analysis can be used by environmental resource managers, public safety and health officials, tourism officials, and local weather forecast offices.  The links below provide details on how researchers in the Southeast are using algorithms, machine learning, and artificial intelligence to develop products specific to the uses below.


### PR DESCRIPTION
Fixes the media referenced on the product page (was referencing a stage video, which was purged at some point)